### PR TITLE
Add missing dependency to URI

### DIFF
--- a/META.json
+++ b/META.json
@@ -42,12 +42,14 @@
       },
       "runtime" : {
          "requires" : {
+            "URI" : "0",
             "perl" : "5.008001"
          }
       },
       "test" : {
          "requires" : {
-            "Test::More" : "0.98"
+            "Test::More" : "0.98",
+            "URI" : "0"
          }
       }
    },

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,8 @@
 requires 'perl', '5.008001';
+requires 'URI';
 
 on 'test' => sub {
+    requires 'URI';
     requires 'Test::More', '0.98';
 };
 


### PR DESCRIPTION
Minilla has URI as dependency, so that's simple to miss this.

Signed-off-by: Michal Josef Špaček <michal.spacek@gooddata.com>